### PR TITLE
[2023-08-03] jisu #93

### DIFF
--- a/Programmers - 문제풀이/이중우선순위큐/jisu.py
+++ b/Programmers - 문제풀이/이중우선순위큐/jisu.py
@@ -4,7 +4,7 @@
 우선순위 큐에서 빈 큐가 아니라면 최대값, 최소값만 구할 수 있으면 된다.
 이를 위해 큐를 최소힙으로 구현한다면 최소 값은 0번쨰 인덱스, 최대 값은 nlargest(1)로 구해낼 수 있다.
 그렇다면 최소값을 삭제하는 연산은 O(1)에 가능할 것 같은데, 최대 값을 삭제하는 것은 O(n) 이상이 걸릴 것
-될까..? 일단 해보자 -> 옹 된당
+될까..? 복잡도가 감이 안잡힘 일단 해보자 -> 옹 된당
 
 풀이 완료 : 2023.08.03 16:06
 
@@ -23,15 +23,15 @@ def solution(operations : List):
 
     for operation in operations:
         op, value = operation.split()
-        if op == 'I':
+        if op == 'I':                       # 삽입 연산
             heappush(heap, int(value))
-        elif heap:
-            if value=='1':
-                heap.remove(*nlargest(1, heap))
-            else:
-                heappop(heap)
+        elif heap:                                  # 최대값 / 최소값 삭제 연산, heap에 원소가 있을 때만 실행
+            if value=='1':                          # 최대값 삭제 연산
+                heap.remove(*nlargest(1, heap))     # 1번째로 큰 값 찾아서 삭제(nlargest의 반환 타입은 list임)
+            else:                                   # 최소값 삭제 연산
+                heappop(heap)                       # min heap이 default이므로 heappop시 최소값 삭제
 
-    return [*nlargest(1, heap), heappop(heap)] if heap else [0, 0]
+    return [*nlargest(1, heap), heappop(heap)] if heap else [0, 0]      # heap에 원소가 있으면 [최대값, 최소값] 반환, 비었으면 [0, 0] 반환
 
 
 def main():

--- a/Programmers - 문제풀이/이중우선순위큐/jisu.py
+++ b/Programmers - 문제풀이/이중우선순위큐/jisu.py
@@ -1,0 +1,44 @@
+'''
+풀이 시작 : 2023.08.03 15:45
+
+우선순위 큐에서 빈 큐가 아니라면 최대값, 최소값만 구할 수 있으면 된다.
+이를 위해 큐를 최소힙으로 구현한다면 최소 값은 0번쨰 인덱스, 최대 값은 nlargest(1)로 구해낼 수 있다.
+그렇다면 최소값을 삭제하는 연산은 O(1)에 가능할 것 같은데, 최대 값을 삭제하는 것은 O(n) 이상이 걸릴 것
+될까..? 일단 해보자 -> 옹 된당
+
+풀이 완료 : 2023.08.03 16:06
+
+### 이번 풀이에 사용했던 [heapq 라이브러리의 시간 복잡도](https://medium.com/plain-simple-software/python-heapq-use-cases-and-time-complexity-ee7cbb60420f)가 헷갈려서 다시 찾아봤다.
+- heappush(heap, value) : 삽입 시에 제자리 찾아가는 과정을 거침, 이진 트리 기반이므로 O(logn)
+- heappop(heap) : 최소값 하나를 삭제 후 힙 구조에 맞춰서 인덱싱을 거침 O(logN)
+- nlargest(m, heap) : heap에서 큰 순서대로 m개 찾아서 반환해줌, 복잡도는 힙의 요소가 n개라고 할 때 O(n+log(m))
+'''
+
+from typing import List
+from heapq import heappush, heappop, nlargest
+
+
+def solution(operations : List):
+    heap:List[str] = list()  # 리스트를 힙으로 활용할 것, 디폴트는 min heap
+
+    for operation in operations:
+        op, value = operation.split()
+        if op == 'I':
+            heappush(heap, int(value))
+        elif heap:
+            if value=='1':
+                heap.remove(*nlargest(1, heap))
+            else:
+                heappop(heap)
+
+    return [*nlargest(1, heap), heappop(heap)] if heap else [0, 0]
+
+
+def main():
+    case1 = ["I 16", "I -5643", "D -1", "D 1", "D 1", "I 123", "D -1"]  # [0, 0]
+    case2 = ["I -45", "I 653", "D 1", "I -642", "I 45", "I 97", "D 1", "D -1", "I 333"] # [333, -45]
+    print(solution(case1))
+    print(solution(case2))
+
+
+main()

--- a/Programmers - 문제풀이/이중우선순위큐/jisu_baekjoon.py
+++ b/Programmers - 문제풀이/이중우선순위큐/jisu_baekjoon.py
@@ -1,0 +1,74 @@
+'''
+이중 우선순위 큐 백준 버전 : 프로그래머스 문제와 동일하지만, 테스트 케이스에 대해 좀 더 엄격한 문제
+풀이 시작 : 2023.08.06 21:25
+
+- 동일하게 min heap으로 구현하되, 보다 효율적으로 최댓값을 삭제해야 함
+- 접근 1 : minheap, maxheap을 관리하는 MinMaxHeap 클래스를 구현해서 해결해보기
+  - 문제는 한 쪽에서 pop 했을 때 다른 한 쪽은 어떻게 없앨꺼냐...
+    - 반대편 heap 맨 뒤에서 부터 탐색해서 없애보기? 맨 뒤에서 부터 있을 확률이 높으니까 조금 더 연산이 줄지 않을까? 안정적이지는 못 한 방법.
+      - 없앤다음에 heapify 해야함
+      - 시간초과...
+'''
+
+import sys
+from typing import List
+from heapq import heappush, heappop, heapify
+
+input = sys.stdin.readline
+
+class MinMaxHeap:
+    def __init__(self):
+        self.minHeap: List = list()
+        self.maxHeap: List = list()
+
+    def empty(self) -> bool:
+        return len(self.minHeap) == len(self.maxHeap) == 0
+
+    def push(self, value: int) -> None:
+        heappush(self.minHeap, value)
+        heappush(self.maxHeap, -value)
+
+    def popMin(self) -> int:
+        result = heappop(self.minHeap)
+        
+        for idx in range(len(self.maxHeap)-1, -1, -1):
+            if self.maxHeap[idx] == -result:
+                self.maxHeap.pop(idx)
+                heapify(self.maxHeap)
+
+        return result
+    
+    def popMax(self) -> int:
+        result = heappop(self.maxHeap)
+
+        for idx in range(len(self.minHeap)-1, -1, -1):
+            if self.minHeap[idx] == -result:
+                self.minHeap.pop(idx)
+                heapify(self.minHeap)
+
+        return -result
+    
+def solution():
+    num_of_testcases = int(input())
+    for _ in range(num_of_testcases):
+
+        heap = MinMaxHeap()
+
+        num_of_operations = int(input())
+        for _ in range(num_of_operations):
+            op, value = input().rstrip().split()
+            value = int(value)
+
+            if op == 'I':
+                heap.push(value)
+
+            elif op == 'D' and not heap.empty():
+                if value == 1:
+                    heap.popMax()
+                else:
+                    heap.popMin()
+
+        print('EMPTY') if heap.empty() else print(*[heap.popMax(), heap.popMin()])
+
+solution()
+

--- a/Programmers - 문제풀이/이중우선순위큐/jisu_baekjoon.py
+++ b/Programmers - 문제풀이/이중우선순위큐/jisu_baekjoon.py
@@ -8,59 +8,132 @@
     - 반대편 heap 맨 뒤에서 부터 탐색해서 없애보기? 맨 뒤에서 부터 있을 확률이 높으니까 조금 더 연산이 줄지 않을까? 안정적이지는 못 한 방법.
       - 없앤다음에 heapify 해야함
       - 시간초과...
+- 접근 2 : 삽입된 수의 유효성 검증 로직 추가
+  - 지금 최대힙, 최소힙을 동시에 활용했을 때 문제가 pop을 했을 때 반대쪽 힙에 이를 반영해주는 데에서 문제임
+  - 그럼 반대쪽에서 pop할 때 이미 삭제된 원소가 나온다면 이를 무효처리해주면 됨
+  - 이를 위해서는 삽입된 원소라는 걸 알리기 위한 별도의 자료구조가 필요함 -> 2^31개의 수를 모두 체크하지 말고 최대 1000000개의 수가 주어지니까 이 순서대로 수가 삽입되어있는 지를 관리하자
+  - 그러기 위해서 삽입할 때 이 자료구조의 인덱스 정보를 같이 넘겨줘야함.
+  - 큐가 비었는지 확인해야하는 경우가 있으니까 원소 고유 개수를 세는 변수를 하나 관리하자.
+  - 막판에 출력 시 pop을 사용해서 출력하면 max, min값을 둘 다 출력하지 못하므로 peek도 구현해야 함, 동일하게 pop으로 이미 삭제한 원소이면 무효처리 해주면 된다.
+
+풀이 완료 : 2023.08.07 12:58
 '''
 
 import sys
 from typing import List
-from heapq import heappush, heappop, heapify
+from heapq import heappush, heappop
 
 input = sys.stdin.readline
 
 class MinMaxHeap:
-    def __init__(self):
-        self.minHeap: List = list()
-        self.maxHeap: List = list()
+    def __init__(self, num_of_operations):
+        '''
+        생성자
+
+        - self.inserted : 현재 이중우선순위큐에 삽입된 수들의 유효성을 관리하는 변수
+        - self.minHeap, self.maxHeap : 이중 우선순위큐를 구현하기 위한 min Heap, max Heap
+        - self.count : 유효한 수들의 개수를 관리하는 변수
+        '''
+        self.inserted: List[bool] = [False for _ in range(num_of_operations)]
+        self.minHeap: List[int] = list()
+        self.maxHeap: List[int] = list()
+        self.count: int = 0
 
     def empty(self) -> bool:
-        return len(self.minHeap) == len(self.maxHeap) == 0
+        '''
+        현재 이중우선순위큐가 비었는지 확인하는 연산
+        '''
+        return self.count == 0
 
-    def push(self, value: int) -> None:
-        heappush(self.minHeap, value)
-        heappush(self.maxHeap, -value)
+    def push(self, value: int, idx: int) -> None:
+        '''
+        이중우선순위큐 삽입 연산
+
+        - 각 힙에 value 값과 함께 현재 입력 순서 인덱스를 삽입한다.
+        - idx번째 순서로 삽입된 수는 유효한 수임을 체크
+        - 최대힙을 구현하기 위해 value에 -기호를 붙혀 삽입해야 한다.
+        '''
+        self.inserted[idx] = True
+        self.count += 1
+        heappush(self.minHeap, (value, idx))
+        heappush(self.maxHeap, (-value, idx))
 
     def popMin(self) -> int:
-        result = heappop(self.minHeap)
+        '''
+        이중우선순위큐 최소값 pop 연산
+
+        - validation : 검증을 위한 boolean 변수
+        - inserted[idx]가 True인 유효한 수가 반환될 때까지 최소 힙에서 반복해서 heappop연산을 수행한다.
+        - 유효하지 않은 수(False)가 반환되었다는 것은 이미 max heap에서 삭제된 수라는 뜻
+        '''
+        validation = False
+
+        while not validation:
+            result, idx = heappop(self.minHeap)
+            validation = self.inserted[idx]
         
-        for idx in range(len(self.maxHeap)-1, -1, -1):
-            if self.maxHeap[idx] == -result:
-                self.maxHeap.pop(idx)
-                heapify(self.maxHeap)
+        self.inserted[idx] = False
+        self.count -= 1
 
         return result
     
+    
     def popMax(self) -> int:
-        result = heappop(self.maxHeap)
+        '''
+        이중우선순위큐 최소값 pop 연산
 
-        for idx in range(len(self.minHeap)-1, -1, -1):
-            if self.minHeap[idx] == -result:
-                self.minHeap.pop(idx)
-                heapify(self.minHeap)
+        - validation : 검증을 위한 boolean 변수
+        - inserted[idx]가 True인 유효한 수가 반환될 때까지 최대 힙에서 반복해서 heappop연산을 수행한다.
+        - 유효하지 않은 수(False)가 반환되었다는 것은 이미 min heap에서 삭제된 수라는 뜻
+        - max heap을 구현하기 위해 value가 음수로 저장되어 있으므로 부호를 반전하여 값을 반환해주어야 함
+        '''
+        validation = False
+
+        while not validation:
+            result, idx = heappop(self.maxHeap)
+            validation = self.inserted[idx]
+    
+        self.inserted[idx] = False
+        self.count -= 1
 
         return -result
+    
+    def peekMin(self) -> int:
+        '''
+        이중우선순위큐 최소값 peek 연산
+
+        - 마지막 반환 시에 pop으로 반환하게 되면 최대, 최소 값을 온전하게 반환하지 못함(큐에 원소가 하나 있는 경우)
+        - 마찬가지로 유효하지 않은 값은 모두 pop해버리고, 유효한 값이 큐의 최 상단에 있으면 이를 반환
+        '''
+        while not self.inserted[self.minHeap[0][1]]:
+            heappop(self.minHeap)
+
+        return self.minHeap[0][0]
+
+    def peekMax(self) -> int:
+        '''
+        이중우선순위큐 최대값 peek 연산
+
+        - 마지막 반환 시에 pop으로 반환하게 되면 최대, 최소 값을 온전하게 반환하지 못함(큐에 원소가 하나 있는 경우)
+        - 마찬가지로 유효하지 않은 값은 모두 pop해버리고, 유효한 값이 큐의 최 상단에 있으면 이를 반환
+        '''
+        while not self.inserted[self.maxHeap[0][1]]:
+            heappop(self.maxHeap)
+
+        return -self.maxHeap[0][0]
+      
     
 def solution():
     num_of_testcases = int(input())
     for _ in range(num_of_testcases):
-
-        heap = MinMaxHeap()
-
         num_of_operations = int(input())
-        for _ in range(num_of_operations):
+        heap = MinMaxHeap(num_of_operations)
+        for idx in range(num_of_operations):
             op, value = input().rstrip().split()
             value = int(value)
 
             if op == 'I':
-                heap.push(value)
+                heap.push(value, idx)
 
             elif op == 'D' and not heap.empty():
                 if value == 1:
@@ -68,7 +141,7 @@ def solution():
                 else:
                     heap.popMin()
 
-        print('EMPTY') if heap.empty() else print(*[heap.popMax(), heap.popMin()])
+        print('EMPTY') if heap.empty() else print(*[heap.peekMax(), heap.peekMin()])
 
 solution()
 


### PR DESCRIPTION
### PR Summary

풀이 시작 : 2023.08.03 15:45
우선순위 큐에서 빈 큐가 아니라면 최대값, 최소값만 구할 수 있으면 된다.
이를 위해 큐를 최소힙으로 구현한다면 최소 값은 0번쨰 인덱스, 최대 값은 nlargest(1)로 구해낼 수 있다.
그렇다면 최소값을 삭제하는 연산은 O(1)에 가능할 것 같은데, 최대 값을 삭제하는 것은 O(n) 이상이 걸릴 것
될까..? 일단 해보자
풀이 완료 : 2023.08.03 16:06
### 이번 풀이에 사용했던 [heapq 라이브러리의 시간 복잡도](https://medium.com/plain-simple-software/python-heapq-use-cases-and-time-complexity-ee7cbb60420f)가 헷갈려서 다시 찾아봤다.
- heappush(heap, value) : 삽입 시에 제자리 찾아가는 과정을 거침, 이진 트리 기반이므로 O(logn)
- heappop(heap) : 최소값 하나를 삭제 후 힙 구조에 맞춰서 인덱싱을 거침 O(logN)
- nlargest(m, heap) : heap에서 큰 순서대로 m개 찾아서 반환해줌, 복잡도는 힙의 요소가 n개라고 할 때 O(n+log(m))

![image](https://github.com/RecoRecoNi/Algorithm-Study/assets/72483874/9581f74b-fbbb-4075-ab12-ca97eb4af0f0)

### 백준 버전 풀이 추가
 이중 우선순위 큐 백준 버전 : 프로그래머스 문제와 동일하지만, 테스트 케이스에 대해 좀 더 엄격한 문제
 풀이 시작 : 2023.08.06 21:25
 - 동일하게 min heap으로 구현하되, 보다 효율적으로 최댓값을 삭제해야 함
 - 접근 1 : minheap, maxheap을 관리하는 MinMaxHeap 클래스를 구현해서 해결해보기
   - 문제는 한 쪽에서 pop 했을 때 다른 한 쪽은 어떻게 없앨꺼냐...
     - 반대편 heap 맨 뒤에서 부터 탐색해서 없애보기? 맨 뒤에서 부터 있을 확률이 높으니까 조금 더 연산이 줄지 않을까? 안정적이지는 못 한 방법.
       - 없앤다음에 heapify 해야함
       - 시간초과...
 - 접근 2 : 삽입된 수의 유효성 검증 로직 추가
   - 지금 최대힙, 최소힙을 동시에 활용했을 때 문제가 pop을 했을 때 반대쪽 힙에 이를 반영해주는 데에서 문제임
   - 그럼 반대쪽에서 pop할 때 이미 삭제된 원소가 나온다면 이를 무효처리해주면 됨
   - 이를 위해서는 삽입된 원소라는 걸 알리기 위한 별도의 자료구조가 필요함 -> 2^31개의 수를 모두 체크하지 말고 최대 1000000개의 수가 주어지니까 이 순서대로 수가 삽입되어있는 지를 관리하자
   - 그러기 위해서 삽입할 때 이 자료구조의 인덱스 정보를 같이 넘겨줘야함.
   - 큐가 비었는지 확인해야하는 경우가 있으니까 원소 고유 개수를 세는 변수를 하나 관리하자.
   - 막판에 출력 시 pop을 사용해서 출력하면 max, min값을 둘 다 출력하지 못하므로 peek도 구현해야 함, 동일하게 pop으로 이미 삭제한 원소이면 무효처리 해주면 된다.
 풀이 완료 : 2023.08.07 12:58


### ISSUE NUMBER
<!-- 이슈 번호를 입력해주세요 -->
- #93
